### PR TITLE
Fix dataset field not included in API payload

### DIFF
--- a/timberlogs/client.py
+++ b/timberlogs/client.py
@@ -271,6 +271,10 @@ class TimberlogsClient:
         if self._config.version:
             payload["version"] = self._config.version
 
+        # Apply dataset: entry-level overrides config-level
+        if "dataset" not in payload and self._config.dataset:
+            payload["dataset"] = self._config.dataset
+
         # Apply defaults if not set in entry
         if "userId" not in payload and self._user_id:
             payload["userId"] = self._user_id
@@ -617,6 +621,7 @@ def create_timberlogs(
     environment: Environment,
     api_key: Optional[str] = None,
     endpoint: str = LOGS_ENDPOINT,
+    dataset: Optional[str] = None,
     version: Optional[str] = None,
     user_id: Optional[str] = None,
     session_id: Optional[str] = None,
@@ -637,6 +642,7 @@ def create_timberlogs(
         environment: The environment (development, staging, production).
         api_key: Your Timberlogs API key (starts with tb_live_ or tb_test_).
         endpoint: The ingestion endpoint URL.
+        dataset: The dataset to send logs to (defaults to "default" server-side).
         version: Your application version.
         user_id: Default user ID for all logs.
         session_id: Default session ID for all logs.
@@ -664,6 +670,7 @@ def create_timberlogs(
         environment=environment,
         api_key=api_key,
         endpoint=endpoint,
+        dataset=dataset,
         version=version,
         user_id=user_id,
         session_id=session_id,

--- a/timberlogs/types.py
+++ b/timberlogs/types.py
@@ -33,6 +33,7 @@ class LogEntryDict(TypedDict, total=False):
     tags: Optional[List[str]]
     flow_id: Optional[str]
     step_index: Optional[int]
+    dataset: Optional[str]
 
 
 @dataclass
@@ -50,6 +51,7 @@ class LogEntry:
     tags: Optional[List[str]] = None
     flow_id: Optional[str] = None
     step_index: Optional[int] = None
+    dataset: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for API serialization."""
@@ -75,6 +77,8 @@ class LogEntry:
             result["flowId"] = self.flow_id
         if self.step_index is not None:
             result["stepIndex"] = self.step_index
+        if self.dataset is not None:
+            result["dataset"] = self.dataset
         return result
 
 
@@ -93,6 +97,7 @@ class TimberlogsConfig:
     environment: Environment
     api_key: Optional[str] = None
     endpoint: str = "https://timberlogs-ingest.enaboapps.workers.dev/v1/logs"
+    dataset: Optional[str] = None
     version: Optional[str] = None
     user_id: Optional[str] = None
     session_id: Optional[str] = None


### PR DESCRIPTION
## Summary
- Add `dataset` field to `LogEntry`, `LogEntryDict`, and `TimberlogsConfig`
- Include dataset in `to_dict()` serialization and `_build_log_payload()`
- Add `dataset` parameter to `create_timberlogs()` factory
- Entry-level dataset overrides config-level dataset

Closes #1

## Test plan
- [x] All 26 existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dataset support to the logging client, enabling logs to be organized by dataset.
  * Dataset can be configured at the client level and overridden on a per-log basis for flexible organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->