### PR TITLE
Fix Flow methods not inheriting client user_id/session_id

### DIFF
--- a/timberlogs/client.py
+++ b/timberlogs/client.py
@@ -81,6 +81,8 @@ class Flow:
             tags=options.tags if options else None,
             flow_id=self._id,
             step_index=self._step_index,
+            user_id=self._client._user_id,
+            session_id=self._client._session_id,
         )
 
         # Handle error objects


### PR DESCRIPTION
## Summary
- Pass client-level `user_id` and `session_id` to `LogEntry` in `Flow._log()`
- Flow logs now inherit user context set via `client.set_user_id()`/`set_session_id()`

Closes #2

## Test plan
- [x] All 26 existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced logging to include user and session context information, enabling better tracking and correlation of system activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->