### PR TITLE
Add input validation for field length constraints

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,6 +11,7 @@ from timberlogs import (
     LogOptions,
     TimberlogsClient,
     TimberlogsConfig,
+    ValidationError,
     create_timberlogs,
 )
 
@@ -739,3 +740,107 @@ class TestHTTPRequests:
         assert len(errors) == 1
         assert "503" in errors[0]
         client.disconnect()
+
+
+class TestValidation:
+    """Tests for input validation."""
+
+    def test_empty_message_rejected(self) -> None:
+        """Test that empty message raises ValidationError."""
+        client = create_timberlogs(
+            source="test-app",
+            environment="development",
+        )
+        with pytest.raises(ValidationError, match="message must be at least 1"):
+            client.info("")
+
+    def test_message_too_long_rejected(self) -> None:
+        """Test that message exceeding 10000 chars raises ValidationError."""
+        client = create_timberlogs(
+            source="test-app",
+            environment="development",
+        )
+        with pytest.raises(ValidationError, match="message exceeds 10000"):
+            client.info("x" * 10001)
+
+    def test_valid_message_accepted(self) -> None:
+        """Test that a valid long message is accepted."""
+        client = create_timberlogs(
+            source="test-app",
+            environment="development",
+        )
+        client.info("x" * 10000)
+
+    def test_too_many_tags_rejected(self) -> None:
+        """Test that more than 20 tags raises ValidationError."""
+        client = create_timberlogs(
+            source="test-app",
+            environment="development",
+        )
+        with pytest.raises(ValidationError, match="tags must have at most 20"):
+            client.info("test", options=LogOptions(tags=[f"tag{i}" for i in range(21)]))
+
+    def test_tag_too_long_rejected(self) -> None:
+        """Test that a tag exceeding 50 chars raises ValidationError."""
+        client = create_timberlogs(
+            source="test-app",
+            environment="development",
+        )
+        with pytest.raises(ValidationError, match="tags\\[0\\] exceeds 50"):
+            client.info("test", options=LogOptions(tags=["x" * 51]))
+
+    def test_user_id_too_long_rejected(self) -> None:
+        """Test that userId exceeding 100 chars raises ValidationError."""
+        client = create_timberlogs(
+            source="test-app",
+            environment="development",
+        )
+        with pytest.raises(ValidationError, match="userId exceeds 100"):
+            client.log(LogEntry(level="info", message="test", user_id="x" * 101))
+
+    def test_error_name_too_long_rejected(self) -> None:
+        """Test that errorName exceeding 200 chars raises ValidationError."""
+        client = create_timberlogs(
+            source="test-app",
+            environment="development",
+        )
+        with pytest.raises(ValidationError, match="errorName exceeds 200"):
+            client.log(LogEntry(
+                level="error",
+                message="test",
+                error_name="x" * 201,
+            ))
+
+    def test_step_index_out_of_range_rejected(self) -> None:
+        """Test that stepIndex > 1000 raises ValidationError."""
+        client = create_timberlogs(
+            source="test-app",
+            environment="development",
+        )
+        with pytest.raises(ValidationError, match="stepIndex must be 0-1000"):
+            client.log(LogEntry(
+                level="info",
+                message="test",
+                flow_id="test-flow",
+                step_index=1001,
+            ))
+
+    def test_valid_payload_passes(self) -> None:
+        """Test that a fully valid payload passes validation."""
+        client = create_timberlogs(
+            source="test-app",
+            environment="development",
+            version="1.0.0",
+            dataset="my-dataset",
+        )
+        client.set_user_id("user_123")
+        client.set_session_id("sess_abc")
+        client.log(LogEntry(
+            level="info",
+            message="Valid message",
+            data={"key": "value"},
+            request_id="req_xyz",
+            tags=["tag1", "tag2"],
+            flow_id="flow-123",
+            step_index=5,
+        ))

--- a/timberlogs/__init__.py
+++ b/timberlogs/__init__.py
@@ -20,6 +20,7 @@ from .types import (
     LogLevel,
     LogOptions,
     TimberlogsConfig,
+    ValidationError,
 )
 
 __version__ = "1.0.0"
@@ -36,6 +37,7 @@ __all__ = [
     "LogEntry",
     "LogOptions",
     "TimberlogsConfig",
+    "ValidationError",
     # Version
     "__version__",
 ]

--- a/timberlogs/client.py
+++ b/timberlogs/client.py
@@ -17,6 +17,7 @@ from .types import (
     LogLevel,
     LogOptions,
     TimberlogsConfig,
+    validate_log_payload,
 )
 
 T = TypeVar("T", bound="TimberlogsClient")
@@ -283,6 +284,7 @@ class TimberlogsClient:
         if "sessionId" not in payload and self._session_id:
             payload["sessionId"] = self._session_id
 
+        validate_log_payload(payload)
         return payload
 
     def log(self, entry: LogEntry) -> "TimberlogsClient":

--- a/timberlogs/types.py
+++ b/timberlogs/types.py
@@ -123,6 +123,62 @@ LOG_LEVEL_PRIORITY: Dict[LogLevel, int] = {
 }
 
 
+class ValidationError(ValueError):
+    """Raised when a log entry or config value fails validation."""
+
+
+def validate_log_payload(payload: Dict[str, Any]) -> None:
+    """Validate a log payload against API constraints.
+
+    Raises:
+        ValidationError: If any field exceeds API limits.
+    """
+    _check_str(payload, "message", 1, 10_000)
+    _check_str(payload, "source", 1, 100)
+    _check_str(payload, "environment", 1, 50)
+    _check_str(payload, "errorName", 0, 200)
+    _check_str(payload, "errorStack", 0, 10_000)
+    _check_str(payload, "userId", 0, 100)
+    _check_str(payload, "sessionId", 0, 100)
+    _check_str(payload, "requestId", 0, 100)
+    _check_str(payload, "version", 0, 50)
+    _check_str(payload, "dataset", 0, 50)
+    _check_str(payload, "flowId", 0, 50)
+
+    if "stepIndex" in payload:
+        step = payload["stepIndex"]
+        if not isinstance(step, int) or step < 0 or step > 1000:
+            raise ValidationError(f"stepIndex must be 0-1000, got {step}")
+
+    tags = payload.get("tags")
+    if tags is not None:
+        if len(tags) > 20:
+            raise ValidationError(f"tags must have at most 20 items, got {len(tags)}")
+        for i, tag in enumerate(tags):
+            if len(tag) > 50:
+                raise ValidationError(
+                    f"tags[{i}] exceeds 50 characters: {len(tag)}"
+                )
+
+
+def _check_str(
+    payload: Dict[str, Any], key: str, min_len: int, max_len: int
+) -> None:
+    value = payload.get(key)
+    if value is None:
+        return
+    if not isinstance(value, str):
+        return
+    if min_len > 0 and len(value) < min_len:
+        raise ValidationError(
+            f"{key} must be at least {min_len} character(s), got {len(value)}"
+        )
+    if len(value) > max_len:
+        raise ValidationError(
+            f"{key} exceeds {max_len} characters: {len(value)}"
+        )
+
+
 __all__ = [
     "LogLevel",
     "Environment",
@@ -132,4 +188,6 @@ __all__ = [
     "LogOptions",
     "TimberlogsConfig",
     "LOG_LEVEL_PRIORITY",
+    "ValidationError",
+    "validate_log_payload",
 ]


### PR DESCRIPTION
## Summary
- Add `validate_log_payload()` with all API constraint checks
- Add `ValidationError` class for clear error reporting
- Validates message, source, tags, userId, sessionId, requestId, version, dataset, flowId, errorName, errorStack, stepIndex
- 9 new validation tests

Closes #6

## Test plan
- [x] All 52 tests pass