### PR TITLE
Narrow exception handling to specific httpx types

### DIFF
--- a/timberlogs/client.py
+++ b/timberlogs/client.py
@@ -450,7 +450,7 @@ class TimberlogsClient:
                 )
                 response.raise_for_status()
                 return  # Success
-            except Exception as e:
+            except (httpx.RequestError, httpx.HTTPStatusError) as e:
                 last_error = e
                 if attempt < max_retries:
                     time.sleep(delay_ms / 1000)
@@ -510,7 +510,7 @@ class TimberlogsClient:
                 )
                 response.raise_for_status()
                 return  # Success
-            except Exception as e:
+            except (httpx.RequestError, httpx.HTTPStatusError) as e:
                 last_error = e
                 if attempt < max_retries:
                     await asyncio.sleep(delay_ms / 1000)


### PR DESCRIPTION
## Summary
- Replace bare `except Exception` with `except (httpx.RequestError, httpx.HTTPStatusError)` in both sync and async retry loops
- Prevents accidentally catching `KeyboardInterrupt`, `SystemExit`, etc.

Closes #8

## Test plan
- [x] All 52 tests pass