### PR TITLE
Fix async HTTP client not closed in sync disconnect

### DIFF
--- a/timberlogs/client.py
+++ b/timberlogs/client.py
@@ -600,6 +600,18 @@ class TimberlogsClient:
             self._http_client.close()
             self._http_client = None
 
+        if self._async_http_client:
+            try:
+                import asyncio
+                loop = asyncio.get_event_loop()
+                if loop.is_running():
+                    loop.create_task(self._async_http_client.aclose())
+                else:
+                    loop.run_until_complete(self._async_http_client.aclose())
+            except RuntimeError:
+                pass
+            self._async_http_client = None
+
     async def disconnect_async(self) -> None:
         """Asynchronously flush logs and stop the client."""
         with self._lock:


### PR DESCRIPTION
## Summary
- Close `_async_http_client` in sync `disconnect()` if it was created via async methods
- Handles both running and non-running event loops gracefully

Closes #10

## Test plan
- [x] All 52 tests pass