### PR TITLE
Add raw format ingest support

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,6 +7,7 @@ import pytest
 
 from timberlogs import (
     Flow,
+    IngestRawOptions,
     LogEntry,
     LogOptions,
     TimberlogsClient,
@@ -844,3 +845,130 @@ class TestValidation:
             flow_id="flow-123",
             step_index=5,
         ))
+
+
+class TestIngestRaw:
+    """Tests for ingest_raw and ingest_raw_async."""
+
+    def test_ingest_raw_raises_without_api_key(self) -> None:
+        client = create_timberlogs(
+            source="test-app",
+            environment="development",
+        )
+        with pytest.raises(RuntimeError, match="api_key"):
+            client.ingest_raw("data", "csv")
+
+    def test_ingest_raw_raises_on_invalid_format(self) -> None:
+        client = create_timberlogs(
+            source="test-app",
+            environment="development",
+            api_key="tb_test_key",
+        )
+        with pytest.raises(ValueError, match="Unsupported format"):
+            client.ingest_raw("data", "invalid")  # type: ignore[arg-type]
+        client.disconnect()
+
+    def test_ingest_raw_sends_correct_request(self, httpx_mock) -> None:
+        httpx_mock.add_response(status_code=200)
+        client = create_timberlogs(
+            source="test-app",
+            environment="production",
+            api_key="tb_test_key",
+            flush_interval=0,
+        )
+        client.ingest_raw(
+            "level,message\ninfo,hello",
+            "csv",
+            IngestRawOptions(source="nginx", environment="production"),
+        )
+
+        requests = httpx_mock.get_requests()
+        assert len(requests) == 1
+        req = requests[0]
+        assert "format=csv" in str(req.url)
+        assert "source=nginx" in str(req.url)
+        assert "environment=production" in str(req.url)
+        assert req.headers["Content-Type"] == "text/csv"
+        assert req.headers["X-API-Key"] == "tb_test_key"
+        assert req.content == b"level,message\ninfo,hello"
+        client.disconnect()
+
+    def test_ingest_raw_sends_jsonl(self, httpx_mock) -> None:
+        httpx_mock.add_response(status_code=200)
+        client = create_timberlogs(
+            source="test-app",
+            environment="production",
+            api_key="tb_test_key",
+            flush_interval=0,
+        )
+        body = '{"message":"line1"}\n{"message":"line2"}'
+        client.ingest_raw(body, "jsonl")
+
+        requests = httpx_mock.get_requests()
+        assert len(requests) == 1
+        assert requests[0].headers["Content-Type"] == "application/x-ndjson"
+        assert "format=jsonl" in str(requests[0].url)
+        client.disconnect()
+
+    def test_ingest_raw_retries_on_failure(self, httpx_mock) -> None:
+        httpx_mock.add_response(status_code=500)
+        httpx_mock.add_response(status_code=200)
+
+        client = create_timberlogs(
+            source="test-app",
+            environment="production",
+            api_key="tb_test_key",
+            max_retries=1,
+            initial_delay_ms=1,
+            max_delay_ms=1,
+            flush_interval=0,
+        )
+        client.ingest_raw("data", "text")
+        assert len(httpx_mock.get_requests()) == 2
+        client.disconnect()
+
+    def test_ingest_raw_raises_after_retries_exhausted(self, httpx_mock) -> None:
+        for _ in range(4):
+            httpx_mock.add_response(status_code=500)
+
+        client = create_timberlogs(
+            source="test-app",
+            environment="production",
+            api_key="tb_test_key",
+            max_retries=3,
+            initial_delay_ms=1,
+            max_delay_ms=1,
+            flush_interval=0,
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            client.ingest_raw("data", "text")
+        client.disconnect()
+
+    async def test_ingest_raw_async_raises_without_api_key(self) -> None:
+        client = create_timberlogs(
+            source="test-app",
+            environment="development",
+        )
+        with pytest.raises(RuntimeError, match="api_key"):
+            await client.ingest_raw_async("data", "csv")
+
+    async def test_ingest_raw_async_sends_correct_request(self, httpx_mock) -> None:
+        httpx_mock.add_response(status_code=200)
+        client = create_timberlogs(
+            source="test-app",
+            environment="production",
+            api_key="tb_test_key",
+            flush_interval=0,
+        )
+        await client.ingest_raw_async(
+            "<134>1 2024-01-01T00:00:00Z host app - - - msg",
+            "syslog",
+            IngestRawOptions(source="syslog-relay"),
+        )
+
+        requests = httpx_mock.get_requests()
+        assert len(requests) == 1
+        assert requests[0].headers["Content-Type"] == "application/x-syslog"
+        assert "format=syslog" in str(requests[0].url)
+        assert "source=syslog-relay" in str(requests[0].url)
+        await client.disconnect_async()

--- a/timberlogs/__init__.py
+++ b/timberlogs/__init__.py
@@ -16,6 +16,9 @@ Example:
 from .client import Flow, TimberlogsClient, create_timberlogs
 from .types import (
     Environment,
+    FormatName,
+    FORMAT_CONTENT_TYPES,
+    IngestRawOptions,
     LogEntry,
     LogLevel,
     LogOptions,
@@ -34,6 +37,9 @@ __all__ = [
     # Types and config
     "LogLevel",
     "Environment",
+    "FormatName",
+    "FORMAT_CONTENT_TYPES",
+    "IngestRawOptions",
     "LogEntry",
     "LogOptions",
     "TimberlogsConfig",

--- a/timberlogs/client.py
+++ b/timberlogs/client.py
@@ -11,8 +11,11 @@ from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
 import httpx
 
 from .types import (
+    FORMAT_CONTENT_TYPES,
     LOG_LEVEL_PRIORITY,
     Environment,
+    FormatName,
+    IngestRawOptions,
     LogEntry,
     LogLevel,
     LogOptions,
@@ -525,6 +528,110 @@ class TimberlogsClient:
 
         if last_error:
             self._handle_error(last_error, logs)
+
+    def _build_raw_url(self, format: FormatName, options: Optional[IngestRawOptions]) -> str:
+        params = {"format": format}
+        if options:
+            if options.source:
+                params["source"] = options.source
+            if options.environment:
+                params["environment"] = options.environment
+            if options.level:
+                params["level"] = options.level
+            if options.dataset:
+                params["dataset"] = options.dataset
+        qs = "&".join(f"{k}={v}" for k, v in params.items())
+        return f"{LOGS_ENDPOINT}?{qs}"
+
+    def ingest_raw(
+        self,
+        body: str,
+        format: FormatName,
+        options: Optional[IngestRawOptions] = None,
+    ) -> None:
+        if not self._config.api_key:
+            raise RuntimeError("HTTP transport requires api_key")
+        if format not in FORMAT_CONTENT_TYPES:
+            raise ValueError(f"Unsupported format: {format}")
+
+        if not self._http_client:
+            self._http_client = httpx.Client(timeout=30.0)
+
+        url = self._build_raw_url(format, options)
+        content_type = FORMAT_CONTENT_TYPES[format]
+
+        retry_config = self._config.retry
+        max_retries = retry_config.get("max_retries", 3)
+        initial_delay_ms = retry_config.get("initial_delay_ms", 1000)
+        max_delay_ms = retry_config.get("max_delay_ms", 30000)
+
+        delay_ms = initial_delay_ms
+        last_error: Optional[Exception] = None
+
+        for attempt in range(max_retries + 1):
+            try:
+                response = self._http_client.post(
+                    url,
+                    content=body,
+                    headers={
+                        "Content-Type": content_type,
+                        "X-API-Key": self._config.api_key,
+                    },
+                )
+                response.raise_for_status()
+                return
+            except (httpx.RequestError, httpx.HTTPStatusError) as e:
+                last_error = e
+                if attempt < max_retries:
+                    time.sleep(delay_ms / 1000)
+                    delay_ms = min(delay_ms * 2, max_delay_ms)
+
+        raise last_error  # type: ignore[misc]
+
+    async def ingest_raw_async(
+        self,
+        body: str,
+        format: FormatName,
+        options: Optional[IngestRawOptions] = None,
+    ) -> None:
+        if not self._config.api_key:
+            raise RuntimeError("HTTP transport requires api_key")
+        if format not in FORMAT_CONTENT_TYPES:
+            raise ValueError(f"Unsupported format: {format}")
+
+        if self._async_http_client is None:
+            self._async_http_client = httpx.AsyncClient(timeout=30.0)
+
+        url = self._build_raw_url(format, options)
+        content_type = FORMAT_CONTENT_TYPES[format]
+
+        retry_config = self._config.retry
+        max_retries = retry_config.get("max_retries", 3)
+        initial_delay_ms = retry_config.get("initial_delay_ms", 1000)
+        max_delay_ms = retry_config.get("max_delay_ms", 30000)
+
+        delay_ms = initial_delay_ms
+        last_error: Optional[Exception] = None
+
+        for attempt in range(max_retries + 1):
+            try:
+                response = await self._async_http_client.post(
+                    url,
+                    content=body,
+                    headers={
+                        "Content-Type": content_type,
+                        "X-API-Key": self._config.api_key,
+                    },
+                )
+                response.raise_for_status()
+                return
+            except (httpx.RequestError, httpx.HTTPStatusError) as e:
+                last_error = e
+                if attempt < max_retries:
+                    await asyncio.sleep(delay_ms / 1000)
+                    delay_ms = min(delay_ms * 2, max_delay_ms)
+
+        raise last_error  # type: ignore[misc]
 
     def flow(self, name: str) -> Flow:
         """Create a new flow for tracking related logs synchronously.

--- a/timberlogs/types.py
+++ b/timberlogs/types.py
@@ -186,6 +186,26 @@ def _check_str(
         )
 
 
+FormatName = Literal["json", "jsonl", "syslog", "text", "csv", "obl"]
+
+FORMAT_CONTENT_TYPES: Dict[str, str] = {
+    "json": "application/json",
+    "jsonl": "application/x-ndjson",
+    "syslog": "application/x-syslog",
+    "text": "text/plain",
+    "csv": "text/csv",
+    "obl": "application/x-obl",
+}
+
+
+@dataclass
+class IngestRawOptions:
+    source: Optional[str] = None
+    environment: Optional[Environment] = None
+    level: Optional[LogLevel] = None
+    dataset: Optional[str] = None
+
+
 __all__ = [
     "LogLevel",
     "Environment",
@@ -197,4 +217,7 @@ __all__ = [
     "LOG_LEVEL_PRIORITY",
     "ValidationError",
     "validate_log_payload",
+    "FormatName",
+    "FORMAT_CONTENT_TYPES",
+    "IngestRawOptions",
 ]


### PR DESCRIPTION
## Summary
- Add `ingest_raw()` (sync) and `ingest_raw_async()` (async) methods to send pre-formatted data directly to the ingest worker
- Support 6 formats: json, jsonl, csv, text, syslog, obl — each mapped to the correct Content-Type header
- Add `FormatName`, `FORMAT_CONTENT_TYPES`, and `IngestRawOptions` types
- Both methods include retry with exponential backoff, matching existing flush behavior

## Test plan
- [x] `pytest` — 60 tests pass, including 8 new tests for `ingest_raw` / `ingest_raw_async`
- [ ] Manual test: send CSV/syslog via `ingest_raw` against live endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added raw data ingestion capability supporting CSV and JSONL formats with automatic format validation and content-type handling.
  * Implemented retry logic with exponential backoff for improved reliability during ingestion.
  * New configurable options for raw ingestion to specify source, environment, level, and dataset.

* **Tests**
  * Added comprehensive test coverage for raw ingestion including error handling, retries, and async operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->